### PR TITLE
fix: include payable amount when zero and respect generateOnZero flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pixeldrive/peppol-toolkit",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "A TypeScript toolkit for building and reading peppol UBL documents",
     "keywords": [
         "peppol",

--- a/src/builder/DocumentBuilder.ts
+++ b/src/builder/DocumentBuilder.ts
@@ -4,6 +4,7 @@ import { CurrencyCode, Invoice, partySchema, CreditNote } from '../documents';
 import XMLAttributes from '../helpers/XMLAttributes';
 import getDateString from '../helpers/getDateString';
 import { z } from 'zod';
+import { isNullish } from '../helpers/isNullish';
 
 const DEFAULT_CUSTOMIZATION_ID =
     'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0';
@@ -766,7 +767,8 @@ export class DocumentBuilder {
             ...this.__buildAmount(
                 'PayableAmount',
                 total.payableAmount,
-                total.payableAmountCurrency ?? currency
+                total.payableAmountCurrency ?? currency,
+                true
             ),
         };
     }
@@ -774,9 +776,11 @@ export class DocumentBuilder {
     private __buildAmount(
         name: string,
         amount: number | undefined,
-        currency: CurrencyCode
+        currency: CurrencyCode,
+        generateOnZero = false
     ) {
-        if (!amount) return {};
+        if (isNullish(amount)) return {};
+        if (!amount && !generateOnZero) return {};
         return {
             [`cbc:${name}`]: {
                 '#text': amount.toFixed(2),

--- a/src/helpers/isNullish.ts
+++ b/src/helpers/isNullish.ts
@@ -1,0 +1,2 @@
+export const isNullish = (value: any): value is null | undefined =>
+    value === null || value === undefined;

--- a/tests/builder-creditnote.test.ts
+++ b/tests/builder-creditnote.test.ts
@@ -66,6 +66,42 @@ describe('Creditnote Builder', () => {
         );
     });
 
+    it('should always include payable amount even when it is zero', () => {
+        const creditNoteXML = toolkit.creditNoteToPeppolUBL({
+            ...basicCreditNote,
+            legalMonetaryTotal: {
+                ...basicCreditNote.legalMonetaryTotal,
+                payableAmount: 0,
+            },
+        });
+
+        expect(creditNoteXML).toContain(
+            '<cbc:PayableAmount currencyID="EUR">0.00</cbc:PayableAmount>'
+        );
+    });
+
+    it('should omit other zero monetary amounts when generateOnZero is false', () => {
+        const creditNoteXML = toolkit.creditNoteToPeppolUBL({
+            ...basicCreditNote,
+            legalMonetaryTotal: {
+                ...basicCreditNote.legalMonetaryTotal,
+                payableAmount: 0,
+                prepaidAmount: 0,
+                allowanceTotalAmount: 0,
+                chargeTotalAmount: 0,
+                payableRoundingAmount: 0,
+            },
+        });
+
+        expect(creditNoteXML).toContain(
+            '<cbc:PayableAmount currencyID="EUR">0.00</cbc:PayableAmount>'
+        );
+        expect(creditNoteXML).not.toContain('<cbc:PrepaidAmount');
+        expect(creditNoteXML).not.toContain('<cbc:AllowanceTotalAmount');
+        expect(creditNoteXML).not.toContain('<cbc:ChargeTotalAmount');
+        expect(creditNoteXML).not.toContain('<cbc:PayableRoundingAmount');
+    });
+
     it('should not nest cac:Party inside specialized party nodes', () => {
         const creditNoteXML = toolkit.creditNoteToPeppolUBL({
             ...basicCreditNote,

--- a/tests/builder-invoice.test.ts
+++ b/tests/builder-invoice.test.ts
@@ -66,6 +66,42 @@ describe('Invoices Builder', () => {
         );
     });
 
+    it('should always include payable amount even when it is zero', () => {
+        const invoiceXML = toolkit.invoiceToPeppolUBL({
+            ...basicInvoice,
+            legalMonetaryTotal: {
+                ...basicInvoice.legalMonetaryTotal,
+                payableAmount: 0,
+            },
+        });
+
+        expect(invoiceXML).toContain(
+            '<cbc:PayableAmount currencyID="EUR">0.00</cbc:PayableAmount>'
+        );
+    });
+
+    it('should omit other zero monetary amounts when generateOnZero is false', () => {
+        const invoiceXML = toolkit.invoiceToPeppolUBL({
+            ...basicInvoice,
+            legalMonetaryTotal: {
+                ...basicInvoice.legalMonetaryTotal,
+                payableAmount: 0,
+                prepaidAmount: 0,
+                allowanceTotalAmount: 0,
+                chargeTotalAmount: 0,
+                payableRoundingAmount: 0,
+            },
+        });
+
+        expect(invoiceXML).toContain(
+            '<cbc:PayableAmount currencyID="EUR">0.00</cbc:PayableAmount>'
+        );
+        expect(invoiceXML).not.toContain('<cbc:PrepaidAmount');
+        expect(invoiceXML).not.toContain('<cbc:AllowanceTotalAmount');
+        expect(invoiceXML).not.toContain('<cbc:ChargeTotalAmount');
+        expect(invoiceXML).not.toContain('<cbc:PayableRoundingAmount');
+    });
+
     it('should not nest cac:Party inside specialized party nodes', () => {
         const invoiceXML = toolkit.invoiceToPeppolUBL({
             ...basicInvoice,


### PR DESCRIPTION
This commit addresses an issue where zero payable amounts were not included correctly and ensures other zero amounts are omitted when the `generateOnZero` flag is set to false.